### PR TITLE
Remove support libs and replace with androidx artifacts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,14 +22,18 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'com.android.support:design:28.0.0'
+    implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation 'androidx.cardview:cardview:1.0.0'
+    implementation 'androidx.navigation:navigation-runtime:2.1.0'
+
+
     implementation 'com.github.barteksc:android-pdf-viewer:2.8.2'
+
+
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    implementation 'com.android.support:recyclerview-v7:28.0.0'
-    implementation 'com.android.support:cardview-v7:28.0.0'
-    implementation 'androidx.navigation:navigation-runtime:2.1.0'
 
 }

--- a/app/src/main/res/layout/book_layout.xml
+++ b/app/src/main/res/layout/book_layout.xml
@@ -44,4 +44,5 @@
         android:layout_gravity="start"
         app:headerLayout="@layout/nav_header"
         app:menu="@menu/nav_drawer_menu" />
+
 </androidx.drawerlayout.widget.DrawerLayout>


### PR DESCRIPTION
I see both support library and androidx being used in gradle build. To make it consistent, the support libs has been replaced by androidx. See more on [what's androidx here](https://developer.android.com/jetpack/androidx)